### PR TITLE
Fix conflicting visibility

### DIFF
--- a/lib/traits/Feature_Extension.php
+++ b/lib/traits/Feature_Extension.php
@@ -29,7 +29,7 @@ trait Feature_Extension {
 	 *
 	 * @var string
 	 */
-	public $name = '';
+	protected $name = '';
 
 	/**
 	 * Callback to do the actions to register whatever this class is intended to extend.


### PR DESCRIPTION
PHP Fatal error:  Underpin\Abstracts\Taxonomy and Underpin\Traits\Feature_Extension define the same property ($name) in the composition of Underpin\Abstracts\Taxonomy